### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled command line

### DIFF
--- a/hw.py
+++ b/hw.py
@@ -24,12 +24,23 @@ def search():
     conn.close()
     return str(result)
 
+# Allowlist of permissible system commands
+ALLOWED_COMMANDS = {
+    "date": "date",
+    "uptime": "uptime",
+    "whoami": "whoami"
+}
+
 @app.route("/rce")
 def rce():
-    # --- Vulnerable: Remote Code Execution ---
-    cmd = request.args.get("cmd")
-    output = os.popen(cmd).read()  # ❌ executes arbitrary commands
-    return f"<pre>{output}</pre>"
+    cmd_key = request.args.get("cmd")
+    # Only allow execution of commands in the allowlist
+    if cmd_key in ALLOWED_COMMANDS:
+        safe_cmd = ALLOWED_COMMANDS[cmd_key]
+        output = os.popen(safe_cmd).read()
+        return f"<pre>{output}</pre>"
+    else:
+        return "<pre>Error: Invalid command.</pre>", 400
 
 @app.route("/xss")
 def xss():


### PR DESCRIPTION
Potential fix for [https://github.com/MVSHoneywellOrg/honewellautofixdemorepo/security/code-scanning/5](https://github.com/MVSHoneywellOrg/honewellautofixdemorepo/security/code-scanning/5)

To fix the uncontrolled command line vulnerability, we must prevent users from running arbitrary shell commands. The recommended best practice is to use an allowlist of safe, pre-defined commands, and only execute those, never executing raw user input. 

**Implementation plan:**  
- Define a dictionary or list of safe commands (e.g. `{"date":"date", "uptime":"uptime", ...}`).
- In the `/rce` route, get the desired command from the user, lookup in the allowlist, and if present, execute only that command—otherwise, return an error message.
- Replace `os.popen(cmd)` with a non-shell-invoking function like `subprocess.run(..., shell=False)` for further safety, but since we're strictly controlling allowed commands, `os.popen` could still be used securely.
- All changes are isolated in the `/rce` route (lines 28-32) and possibly a global definition for the allowlist.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
